### PR TITLE
quote USERNAME and PASSWORD

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,4 +13,4 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: run code
-        run: python3 run.py -u ${{ secrets.USERNAME }} -p ${{ secrets.PASSWORD }}
+        run: python3 run.py -u '${{ secrets.USERNAME }}' -p '${{ secrets.PASSWORD }}'


### PR DESCRIPTION
If there are special characters in the username or password, the not-quoted shell command would fail.